### PR TITLE
[BCP-003-002] JSON Web Token Claim Values

### DIFF
--- a/APIs/schemas/jwt_schema.json
+++ b/APIs/schemas/jwt_schema.json
@@ -41,16 +41,19 @@
           "properties": {
             "access": {
               "type": "string",
-              "description": "Access Rights to API (read/write)"
+              "description": "Access Rights to API",
+              "enum": ["read", "write", "none"]
             },
             "versions": {
               "type": "array",
               "description": "List of compatible API versions",
               "items": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^v[0-9]\\.[0-9]$"
               }
             }
-          }
+          },
+          "required": ["access", "versions"]
         }
       },
       "additionalProperties": false

--- a/APIs/schemas/jwt_schema.json
+++ b/APIs/schemas/jwt_schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Web Token Claims",
+  "description": "Object defining the contents of an IS-10 JSON Web Token",
+  "type": "object",
+  "properties": {
+    "iss": {
+      "description": "Identifies principal that issued the JWT",
+      "type": "string",
+    },
+    "sub": {
+      "description": "Identifies the subject of the JWT",
+      "type": "string",
+    },
+    "aud": {
+      "description": "Identifies the recipients of the JWT. Can accept wildcard characters",
+      "type": "array",
+      "items": {
+        "type": "string",
+      }
+    },
+    "exp": {
+      "description": "Expiration time (UTC epoch) of the token",
+      "type": "number",
+    },
+    "iat": {
+      "description": "Token issued at time (UTC Epoch)",
+      "type": "number",
+    },
+    "scope": {
+      "description": "Space-delimited list of permissable scopes",
+      "type": "string",
+    },
+    "x-nmos-api": {
+      "description": "Private NMOS-specific claim identifying API name and access rights",
+      "type": "object",
+      "patternProperties": {
+        "^is-[0-9]{2}$": {
+          "description": "Object with key representing IS number of API",
+          "type": "object",
+          "properties": {
+            "access": {
+              "type": "string",
+              "description": "Access Rights to API (read/write)"
+            },
+            "versions": {
+              "type": "array",
+              "description": "List of compatible API versions",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["iss", "sub", "aud", "exp", "iat", "scope", "x-nmos-api"]
+}

--- a/best-practice-authorization.md
+++ b/best-practice-authorization.md
@@ -421,15 +421,17 @@ in the HTTP GET request that initiates the Websocket handshake defined in
 The Resource Server SHALL validate such tokens in the same manner as it would for a normal
 protected HTTP resources using the HTTP Authorization Request Header.
 
-Further to this, due to limitations
-in the native Javascript Websocket API, clients MAY pass the OAuth2 access token in the query parameters
-of the request URL during the handshake, using the `access_token` key, as described in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.3). This is only for situations in which it is not feasible to pass the token in the HTTP Authorization Header.
+Further to this, due to limitations in the native JavaScript Websocket API, clients MAY
+pass the OAuth2 access token in the query parameters of the request URL during the handshake,
+using the `access_token` key, as described in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.3).
+This is only for situations in which it is not feasible to pass the token in the HTTP Authorization Header.
 
 ```
 https://www.example.com/ws?access_token=mF_9.B5f-4.1JqM
 ```
 
-The Authorization server SHALL NOT upgrade the connection to a
+The Resource Server MUST support the parsing of access tokens in both the Authorization
+HTTP Header and the query parameter. The Authorization server SHALL NOT upgrade the connection to a
 WebSocket if the token is deemed invalid.
 
 ## Interaction With Other AMWA Specifications

--- a/best-practice-authorization.md
+++ b/best-practice-authorization.md
@@ -117,7 +117,7 @@ Multiple DNS-SD advertisements for the same API are permitted where the API is e
 
 Clients and Resource Servers MUST support discovering the Authorization Server through use of unicast DNS-SD service discovery, as described in [RFC 6763][RFC-6763].
 
-Clients and Resource Servers MUST verify the TLS certificate of the Authorization Server. Clients MUST check that the address of the Authorization Server matches either a Subject Alternate Name or Common Name on the TLS certificate. 
+Clients and Resource Servers MUST verify the TLS certificate of the Authorization Server. Clients MUST check that the address of the Authorization Server matches either a Subject Alternate Name or Common Name on the TLS certificate.
 Clients MUST verify the entire chain of trust of the Authorization Server TLS certificate, back to a trusted root certificate.
 This ensures that the authorization server is trusted.
 Clients and Resource Servers MUST provide a mechanism for installing root CA certificates used for verifying the TLS certificate of Authorization Servers. HTTPS MUST be used for all connections to the Authorization Server. Clients and Resource Servers MUST NOT interact with Authorization Servers if the TLS certificate of the Authorization Server cannot be validated.
@@ -220,8 +220,8 @@ relationship with the client - this is typically reserved for clients like opera
 privileged software. This may be the case for native application broadcast control systems, but not those
 implemented in the user-agent (e.g browser). This grant is not suitable for NMOS Node type clients.
 
-The client authentication grant is suitable for confidential clients, but requires the resource owner 
-arrange for the Authorization Server to allow access to protected resources out of band rather than as part 
+The client authentication grant is suitable for confidential clients, but requires the resource owner
+arrange for the Authorization Server to allow access to protected resources out of band rather than as part
 of the grant process.
 This may be suitable for use with NMOS, especially where the Authorization Server forms part of a
 larger broadcast control system.
@@ -384,7 +384,7 @@ available in the header for both the token and all other HTTP headers.
 ### Token Lifetime and Refresh
 
 A given token for an NMOS API may be used on more than one Node or Registry instance.
-If one of these Nodes or Registries is compromised, it is possible for that entity to "capture" that token, 
+If one of these Nodes or Registries is compromised, it is possible for that entity to "capture" that token,
 and use it itself maliciously.
 While the precise duration of token validity should be left to implementers and administrators based on the
 risk profile, these tokens SHOULD ideally be set to be valid for no more than one hour.
@@ -418,8 +418,18 @@ in the HTTP GET request that initiates the Websocket handshake defined in
 [RFC 6455][RFC-6455] in the same manner as a normal HTTP request as described in
 [Accessing Protected Resources](#accessing-protected-resources).
 
-The Authorization SHALL validate such tokens in the same manner as it would for a normal
-protected HTTP resources. The Authorization server SHALL NOT upgrade the connection to a
+The Resource Server SHALL validate such tokens in the same manner as it would for a normal
+protected HTTP resources using the HTTP Authorization Request Header.
+
+Further to this, due to limitations
+in the native Javascript Websocket API, clients MAY pass the OAuth2 access token in the query parameters
+of the request URL during the handshake, using the `access_token` key, as described in [RFC 6750](https://tools.ietf.org/html/rfc6750#section-2.3). This is only for situations in which it is not feasible to pass the token in the HTTP Authorization Header.
+
+```
+https://www.example.com/ws?access_token=mF_9.B5f-4.1JqM
+```
+
+The Authorization server SHALL NOT upgrade the connection to a
 WebSocket if the token is deemed invalid.
 
 ## Interaction With Other AMWA Specifications

--- a/examples/jwt_example.json
+++ b/examples/jwt_example.json
@@ -1,0 +1,20 @@
+{
+  "sub": "example_user",
+  "x-nmos-api": {
+    "is-04": {
+      "access": "write",
+      "versions": ["v1.0", "v1.1", "v1.2"]
+    },
+    "is-05": {
+      "access": "read",
+      "versions": ["v1.0", "v1.1"]
+    }
+  },
+  "scope": "is-04 is-05",
+  "iss": "auth.example.co.uk",
+  "iat": 1565006877,
+  "aud": [
+    "*"
+  ],
+  "exp": 1565006937
+}


### PR DESCRIPTION
So I thought I'd add an initial draft of what the contents of a JSON Web Token _might_ look like for use with the IS-10 Authorization process. This is a very rough first draft so feel free to pull it to pieces. Please find a JSON schema and a JSON example in this PR.

There are a multitude of factors to consider when tackling this issue, which ultimately revolves around trying to balance the following aspects:
- Network overhead - Do we want the tokens to be self-signed and self-contained? Thus meaning the resource server can validate the JWT itself, rather than having to hand off the validation process to the Authorization Server? This would likely mean more verbose tokens but with less network chatter. It also moves the validation process to the Resource Server instead of the Auth Server. That might be a bad thing?
- Size and complexity of tokens - These tokens ultimately have to live within the HTTP Authorization Header (most servers implement an 8KB restriction) so they can't be too large. Also these tokens will likely be passed with every HTTP request in the network, so keeping the size lower is beneficial. Also, with larger, more complex tokens comes with it the requirement of increased processing - obviously with some hardware-based devices, processing power might be limited. 
- Population of claims - the granularity is also an issue. Can a token be used against multiple APIs or is it a 1-to-1 mapping between API and token? I'd argue for the sake of simplicity, that a token can be used against multiple NMOS APIs (as most OAuth providers allow tokens with many scopes.) If the `aud` claim is populated with specific nodes/devices, then a new token will likely need to be requested with every API interaction, but the scopes would be nice and granular. Or are tokens requested initially without knowledge of specific nodes/devices, in which case the `aud` claim could be populated with wild card characters, making them more universal? I've assumed wild carding is permissible in my examples.

That's a bit of a stream of consciousness, but food for thought.