### PR TITLE
Added GitHub Lint and Render workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: Lint
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Setup
+        run: make distclean build-tools
+      - name: Lint
+        run: make lint

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -1,0 +1,48 @@
+name: Render
+on:
+  push:
+    branches:
+        - 'v[0-9]*.[0-9]*'
+        - 'publish-*'
+    tags:
+        - 'v[0-9]*.[0-9]*'
+  release:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Uses Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Setup
+        run: make distclean build-tools
+      - name: Build
+        run: make build
+      - name: Remove source-repo
+        run: rm -rf source-repo/
+      - name: Add and Commit
+        uses: EndBug/add-and-commit@v5
+        with:
+          author_name: AMWA
+          author_email: info@amwa.tv
+          message: "Build for Github Pages"
+          add: '.'
+          branch: gh-pages
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+
+


### PR DESCRIPTION
We propose to move to GitHub Actions for CI.  This adds two workflow YAML definitions for Lint and Render.  

Although the render scripts (in https://github.com/AMWA-TV/nmos-doc-build-scripts) aren't changed much, this no longer uses a daily render, instead a push to a vX.X* branch or tag, or a publish-* branch, or making a release triggers the Render workflow. For now it still pushes to gh-pages and gets served from github.io -- longer term we expect to add the Jekyll build and upload to a separate AMWA-owned (cloud) server .

This is the first "real" NMOS repo I'm trying so review helpful. Has been tested on https://github.com/peterbrightwell/nmos-action-test and https://github.com/AMWA-TV/nmos-template. 
